### PR TITLE
Ensure sync pagination uses createdAt cursor

### DIFF
--- a/infra/openapi/openapi.yaml
+++ b/infra/openapi/openapi.yaml
@@ -1,0 +1,30 @@
+openapi: 3.1.0
+info:
+  title: CleanOps API
+  version: 1.0.0
+paths:
+  /sync/events:
+    get:
+      summary: Retrieve sync events
+      parameters:
+        - in: query
+          name: since
+          schema:
+            type: string
+          description: |
+            Cursor representing the last event that the client has processed. The
+            server resolves the cursor to the event's creation timestamp and
+            returns every event created after that timestamp. When multiple events
+            share the same creation time, events with lexicographically greater
+            identifiers are returned to guarantee chronological delivery.
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 100
+            minimum: 1
+            maximum: 500
+          description: Maximum number of events to return.
+      responses:
+        '200':
+          description: Successful response containing ordered events.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cleanops",
+  "version": "1.0.0",
+  "description": "Cleaning Operations Management",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/packages/api/src/sync/__tests__/sync.service.test.js
+++ b/packages/api/src/sync/__tests__/sync.service.test.js
@@ -1,0 +1,127 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { SyncService } = require('../sync.service.js');
+
+class FakeSyncEventDelegate {
+  constructor(events) {
+    this.events = events;
+  }
+
+  async findUnique({ where }) {
+    return (
+      this.events.find((event) => event.id === where.id) ?? null
+    );
+  }
+
+  async findMany({ where, orderBy, take }) {
+    let results = [...this.events];
+
+    if (where?.OR) {
+      const [newerThan, tieBreaker] = where.OR;
+      const pivotDate = newerThan.createdAt?.gt;
+      const pivotId = tieBreaker?.id?.gt;
+
+      results = results.filter((event) => {
+        if (pivotDate && event.createdAt > pivotDate) {
+          return true;
+        }
+
+        if (
+          pivotDate &&
+          pivotId &&
+          event.createdAt.getTime() === pivotDate.getTime() &&
+          event.id > pivotId
+        ) {
+          return true;
+        }
+
+        return !pivotDate;
+      });
+    }
+
+    if (orderBy) {
+      results.sort((a, b) => {
+        for (const clause of orderBy) {
+          const [[field, direction]] = Object.entries(clause);
+          let comparison = 0;
+
+          if (field === 'createdAt') {
+            comparison = a.createdAt.getTime() - b.createdAt.getTime();
+          } else if (field === 'id') {
+            comparison = a.id.localeCompare(b.id);
+          }
+
+          if (comparison !== 0) {
+            return direction === 'asc' ? comparison : -comparison;
+          }
+        }
+
+        return 0;
+      });
+    }
+
+    if (typeof take === 'number') {
+      results = results.slice(0, take);
+    }
+
+    return results;
+  }
+}
+
+class FakePrisma {
+  constructor(events) {
+    this.syncEvent = new FakeSyncEventDelegate(events);
+  }
+}
+
+test('listEvents returns chronologically ordered results after a cursor', async () => {
+  const chronological = [
+    { id: 'clv9t4gdy0000xj9k13', createdAt: new Date('2024-01-01T00:00:00.000Z') },
+    { id: 'clv9t4gdy0001xj9k13', createdAt: new Date('2024-01-01T00:01:00.000Z') },
+    { id: 'clv9t4gdy0002xj9k13', createdAt: new Date('2024-01-01T00:02:00.000Z') },
+    { id: 'clv9t4gdy0003xj9k13', createdAt: new Date('2024-01-01T00:03:00.000Z') },
+    { id: 'clv9t4gdy0004xj9k13', createdAt: new Date('2024-01-01T00:04:00.000Z') },
+  ];
+
+  const shuffled = [chronological[2], chronological[4], chronological[0], chronological[3], chronological[1]];
+
+  const service = new SyncService(new FakePrisma(shuffled));
+  const sinceId = chronological[1].id;
+
+  const results = await service.listEvents({ since: sinceId });
+  const expected = chronological.slice(2).map((event) => event.id);
+
+  assert.deepStrictEqual(
+    results.map((event) => event.id),
+    expected,
+  );
+
+  assert.ok(
+    results.every((event, index, array) =>
+      index === 0 || array[index - 1].createdAt <= event.createdAt,
+    ),
+    'results should be chronological',
+  );
+});
+
+test('listEvents includes siblings sharing the same createdAt using id tiebreakers', async () => {
+  const createdAt = new Date('2024-01-01T00:00:00.000Z');
+  const chronological = [
+    { id: 'clv9t4gdy0000xj9k13', createdAt },
+    { id: 'clv9t4gdy0001xj9k13', createdAt },
+    { id: 'clv9t4gdy0002xj9k13', createdAt },
+  ];
+
+  const shuffled = [chronological[2], chronological[0], chronological[1]];
+
+  const service = new SyncService(new FakePrisma(shuffled));
+  const sinceId = chronological[0].id;
+
+  const results = await service.listEvents({ since: sinceId });
+  const expected = chronological.slice(1).map((event) => event.id);
+
+  assert.deepStrictEqual(
+    results.map((event) => event.id),
+    expected,
+  );
+});

--- a/packages/api/src/sync/sync.service.js
+++ b/packages/api/src/sync/sync.service.js
@@ -1,0 +1,50 @@
+const DEFAULT_LIMIT = 100;
+
+class SyncService {
+  constructor(prisma) {
+    this.prisma = prisma;
+  }
+
+  async listEvents(query = {}) {
+    const { since, limit = DEFAULT_LIMIT } = query;
+
+    let pivot = null;
+
+    if (since) {
+      pivot = await this.prisma.syncEvent.findUnique({
+        where: { id: since },
+        select: { id: true, createdAt: true },
+      });
+
+      if (!pivot) {
+        return [];
+      }
+    }
+
+    const where = pivot
+      ? {
+          OR: [
+            { createdAt: { gt: pivot.createdAt } },
+            {
+              createdAt: pivot.createdAt,
+              id: { gt: pivot.id },
+            },
+          ],
+        }
+      : undefined;
+
+    return this.prisma.syncEvent.findMany({
+      where,
+      orderBy: [
+        { createdAt: "asc" },
+        { id: "asc" },
+      ],
+      take: limit,
+    });
+  }
+}
+
+module.exports = {
+  SyncService,
+  DEFAULT_LIMIT,
+};

--- a/packages/api/src/sync/sync.service.ts
+++ b/packages/api/src/sync/sync.service.ts
@@ -1,0 +1,86 @@
+export interface SyncEvent {
+  id: string;
+  createdAt: Date;
+  [key: string]: unknown;
+}
+
+export interface SyncQuery {
+  since?: string;
+  limit?: number;
+}
+
+export interface SyncEventPivot {
+  id: string;
+  createdAt: Date;
+}
+
+export interface SyncEventWhere {
+  OR?: Array<
+    | { createdAt: { gt: Date } }
+    | { createdAt: Date; id: { gt: string } }
+  >;
+}
+
+export type SyncEventOrderBy =
+  | { createdAt: "asc" | "desc" }
+  | { id: "asc" | "desc" };
+
+export interface SyncEventDelegate {
+  findMany(args: {
+    where?: SyncEventWhere;
+    orderBy?: SyncEventOrderBy[];
+    take?: number;
+  }): Promise<SyncEvent[]>;
+  findUnique(args: {
+    where: { id: string };
+    select: { id: boolean; createdAt: boolean };
+  }): Promise<SyncEventPivot | null>;
+}
+
+export interface PrismaLike {
+  syncEvent: SyncEventDelegate;
+}
+
+export const DEFAULT_LIMIT = 100;
+
+export class SyncService {
+  constructor(private readonly prisma: PrismaLike) {}
+
+  async listEvents(query: SyncQuery = {}): Promise<SyncEvent[]> {
+    const { since, limit = DEFAULT_LIMIT } = query;
+
+    let pivot: SyncEventPivot | null = null;
+
+    if (since) {
+      pivot = await this.prisma.syncEvent.findUnique({
+        where: { id: since },
+        select: { id: true, createdAt: true },
+      });
+
+      if (!pivot) {
+        return [];
+      }
+    }
+
+    const where = pivot
+      ? {
+          OR: [
+            { createdAt: { gt: pivot.createdAt } },
+            {
+              createdAt: pivot.createdAt,
+              id: { gt: pivot.id },
+            },
+          ],
+        }
+      : undefined;
+
+    return this.prisma.syncEvent.findMany({
+      where,
+      orderBy: [
+        { createdAt: "asc" },
+        { id: "asc" },
+      ],
+      take: limit,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- fetch sync events in chronological order by looking up the cursor's createdAt timestamp and filtering/tie-breaking with createdAt + id
- document the new cursor semantics in the OpenAPI definition
- add regression tests that shuffle event ids and confirm since-based pagination still returns every later event

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfe2fa89448323aec72125a54b6960